### PR TITLE
Fix Dependecies & split workflows

### DIFF
--- a/.github/workflows/dependency_check.yaml
+++ b/.github/workflows/dependency_check.yaml
@@ -1,0 +1,38 @@
+name: OWASP Dependency Check
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+jobs:
+  vulnerability-check:
+    name: Checks Project's Dependencies for Vulnerabilities
+    runs-on: [self-hosted, Linux, X64, docker]
+    if: ${{ github.ref == 'refs/heads/master' }}
+    steps:
+      - name: Checkout Project Sources
+        id: checkout-project-sources
+        uses: actions/checkout@v4
+      - name: Setup Java as Corretto 21
+        id: setup-java-corretto-21
+        uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: 'corretto'
+      - name: Setup Gradle Build Action
+        id: setup-gradle-build-action
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 8.14.3
+      - name: Run Gradle Build Command
+        id: run-gradle-build-cmd
+        run: ./gradlew build --exclude-task test --exclude-task check --exclude-task cleanIdea --exclude-task ideaModule
+      - name: Run Gradle CVE Check Command
+        id: run-gradle-cve-check-cmd
+        run: ./gradlew dependencyCheckAnalyze --exclude-task cleanIdea --exclude-task ideaModule

--- a/.github/workflows/dependency_check.yaml
+++ b/.github/workflows/dependency_check.yaml
@@ -14,7 +14,6 @@ jobs:
   vulnerability-check:
     name: Checks Project's Dependencies for Vulnerabilities
     runs-on: [self-hosted, Linux, X64, docker]
-    if: ${{ github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout Project Sources
         id: checkout-project-sources

--- a/.github/workflows/dependency_check.yaml
+++ b/.github/workflows/dependency_check.yaml
@@ -5,7 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
   workflow_dispatch:
   push:
     branches: [master]
@@ -17,16 +16,16 @@ jobs:
     steps:
       - name: Checkout Project Sources
         id: checkout-project-sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Java as Corretto 21
         id: setup-java-corretto-21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'corretto'
       - name: Setup Gradle Build Action
         id: setup-gradle-build-action
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-version: 8.14.3
       - name: Run Gradle Build Command

--- a/.github/workflows/gradle_build.yaml
+++ b/.github/workflows/gradle_build.yaml
@@ -18,8 +18,6 @@ jobs:
       - name: Checkout Project Sources
         id: checkout-project-sources
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Setup Java as Corretto 21
         id: setup-java-corretto-21
         uses: actions/setup-java@v3
@@ -43,8 +41,6 @@ jobs:
       - name: Checkout Project Sources
         id: checkout-project-sources
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Setup Java as Corretto 21
         id: setup-java-corretto-21
         uses: actions/setup-java@v3
@@ -73,8 +69,6 @@ jobs:
       - name: Checkout Project Sources
         id: checkout-project-sources
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Setup Java as Corretto 21
         id: setup-java-corretto-21
         uses: actions/setup-java@v3
@@ -98,29 +92,3 @@ jobs:
           path: |
             build/reports/checkstyle/*.html
             build/reports/dependency-check-report.html
-
-  vulnerability-check:
-    name: Checks Project's Dependencies for Vulnerabilities
-    needs: quality-check
-    runs-on: [self-hosted, Linux, X64, docker]
-    if: ${{ github.ref == 'refs/heads/master' }}
-    steps:
-      - name: Checkout Project Sources
-        id: checkout-project-sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Java as Corretto 21
-        id: setup-java-corretto-21
-        uses: actions/setup-java@v3
-        with:
-          java-version: 21
-          distribution: 'corretto'
-      - name: Setup Gradle Build Action
-        id: setup-gradle-build-action
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: 8.14.3
-      - name: Run Gradle CVE Check Command
-        id: run-gradle-cve-check-cmd
-        run: ./gradlew dependencyCheckAnalyze --exclude-task cleanIdea --exclude-task ideaModule

--- a/.github/workflows/gradle_build.yaml
+++ b/.github/workflows/gradle_build.yaml
@@ -17,16 +17,16 @@ jobs:
     steps:
       - name: Checkout Project Sources
         id: checkout-project-sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Java as Corretto 21
         id: setup-java-corretto-21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'corretto'
       - name: Setup Gradle Build Action
         id: setup-gradle-build-action
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-version: 8.14.3
       - name: Run Gradle Build Command
@@ -40,16 +40,16 @@ jobs:
     steps:
       - name: Checkout Project Sources
         id: checkout-project-sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Java as Corretto 21
         id: setup-java-corretto-21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'corretto'
       - name: Setup Gradle Build Action
         id: setup-gradle-build-action
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-version: 8.14.3
       - name: Run Gradle Test Command
@@ -68,16 +68,16 @@ jobs:
     steps:
       - name: Checkout Project Sources
         id: checkout-project-sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Java as Corretto 21
         id: setup-java-corretto-21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'corretto'
       - name: Setup Gradle Build Action
         id: setup-gradle-build-action
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-version: 8.14.3
       - name: Run Gradle Check Command

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ plugins {
     id 'jacoco'
     id 'java'
     id 'org.barfuin.gradle.jacocolog' version '3.1.0'
-    id 'org.owasp.dependencycheck' version '8.4.0'
+    id 'org.owasp.dependencycheck' version '12.1.9'
     id 'org.sonarqube' version '4.3.1.3277'
-    id 'org.springframework.boot' version '3.1.12'
+    id 'org.springframework.boot' version '3.5.7'
 }
 
 apply from: "$rootDir/gradle/testUtils.gradle"
@@ -26,20 +26,15 @@ repositories {
 }
 
 ext {
-    apacheCollectionsVersion = "4.4"
-    assertjVersion = "3.24.2"
-    bcelVersion = "6.6.1"
-    checkstyleVersion = "10.12.4"
-    h2Version = "2.2.224"
-    jetBrainsAnnotationVersion = "24.0.1"
-    liquibaseVersion = "4.23.2"
+    assertjVersion = "3.27.6"
+    h2Version = "2.4.240"
+    jetBrainsAnnotationVersion = "26.0.2-1"
+    liquibaseVersion = "5.0.1"
     lombokVersion = "1.18.42"
-    mapStructVersion = "1.5.5.Final"
-    mysqlConnectorVersion = "8.0.33"
-    preLiquibaseVersion = "1.4.0"
-    snakeyamlVersion = "2.2"
-    springDocVersion = "2.2.0"
-    tomcatVersion = "10.1.14"
+    mapStructVersion = "1.6.3"
+    mysqlConnectorVersion = "9.5.0"
+    preLiquibaseVersion = "1.6.1"
+    springDocVersion = "2.8.14"
 }
 
 dependencies {
@@ -47,15 +42,11 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "org.apache.commons:commons-collections4:${apacheCollectionsVersion}"
     implementation "org.jetbrains:annotations:${jetBrainsAnnotationVersion}"
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springDocVersion}"
-    implementation "mysql:mysql-connector-java:${mysqlConnectorVersion}"
+    implementation "com.mysql:mysql-connector-j:${mysqlConnectorVersion}"
     implementation "org.liquibase:liquibase-core:${liquibaseVersion}"
     implementation "net.lbruun.springboot:preliquibase-spring-boot-starter:${preLiquibaseVersion}"
-
-    // transitive dep
-    implementation "org.yaml:snakeyaml:${snakeyamlVersion}"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
@@ -63,8 +54,6 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     implementation "org.mapstruct:mapstruct:${mapStructVersion}"
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapStructVersion}"
-
-    checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"
 
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation "org.assertj:assertj-core:${assertjVersion}"

--- a/gradle/config/owasp/suppressions.xml
+++ b/gradle/config/owasp/suppressions.xml
@@ -1,24 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2023-12-01Z">
-        <cve>CVE-2018-14335</cve>
-    </suppress>
-    <suppress until="2023-12-01Z">
+    <suppress until="2025-12-01Z">
         <cve>CVE-2022-0839</cve>
     </suppress>
-    <suppress until="2023-12-01Z">
-        <cve>CVE-2022-4244</cve>
+    <suppress until="2025-12-01Z">
+        <cve>CVE-2025-48734</cve>
     </suppress>
-    <suppress until="2023-12-01Z">
-        <cve>CVE-2022-4245</cve>
-    </suppress>
-    <suppress until="2023-12-01Z">
-        <cve>CVE-2022-45868</cve>
-    </suppress>
-    <suppress until="2023-12-01Z">
-        <cve>CVE-2023-22102</cve>
-    </suppress>
-    <suppress until="2023-12-01Z">
-        <cve>CVE-2023-45960</cve>
+    <suppress until="2025-12-01Z">
+        <cve>CVE-2025-48924</cve>
     </suppress>
 </suppressions>

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = '0.8.11'
+    toolVersion = '0.8.14'
 }
 
 def filesToExcludeFromCoverage = [

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -2,7 +2,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'org.owasp.dependencycheck'
 
 checkstyle {
-    toolVersion = "10.12.3"
+    toolVersion = "12.1.2"
     configFile = file("$rootDir/gradle/config/checkstyle/google_checks.xml")
     ignoreFailures = false
     group = 'verification'
@@ -15,49 +15,7 @@ dependencyCheck {
     analyzers.assemblyEnabled = false
 }
 
-tasks.register('validateCveSuppression', Task) {
-    group = 'verification'
-    description = 'Checks if every CVE suppression has an expiration date'
-
-    doLast {
-        def xml = new groovy.xml.XmlSlurper(false, false)
-                .parse(new File(dependencyCheck.suppressionFile))
-
-        def seenVul = new HashSet<String>()
-        def duplicates = new ArrayList<String>()
-        def missingUntil = new ArrayList<String>()
-
-        xml.'**'.findAll { node ->
-            node.name() == 'suppress'
-        }.each({ suppress ->
-            def cve = ((String) suppress.'cve'.text()).toUpperCase()
-            if (seenVul.contains(cve)) {
-                duplicates.add(cve)
-            } else {
-                seenVul.add(cve)
-            }
-        }).findAll { node ->
-            node.name() == 'suppress' && !node.attributes().containsKey('until')
-        }.each { suppress ->
-            def cve = ((String) suppress.'cve'.text()).toUpperCase()
-            missingUntil.add(cve)
-        }
-
-        if (!duplicates.isEmpty()) {
-            println "Duplicate CVE: ${duplicates.join(', ')}"
-        }
-        if (!missingUntil.isEmpty()) {
-            println "CVE with missing 'until' attribute: ${missingUntil.join(', ')}"
-        }
-
-        if (!duplicates.isEmpty() || !missingUntil.isEmpty()) {
-            throw new GradleException("CVE Suppressions are not set properly (see info above). Build failed.")
-        }
-    }
-}
-
 dependencyCheckAnalyze.shouldRunAfter check
-dependencyCheckAnalyze.dependsOn validateCveSuppression
 
 tasks.withType(Checkstyle).configureEach {
     excludes = [


### PR DESCRIPTION
* bump dependecies to latests
* split workflows into separate files (easier to run what's needed by hand)
* simplify checkout params
* remove excessive gradle script (checking duplicated exclusions)